### PR TITLE
Allow `dockerLabels` to be configured on container

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,8 @@ locals {
         awslogs-stream-prefix = var.name
       }
     }
+
+    dockerLabels = var.docker_labels
   }
 
   volumes = concat(var.ecs_launch_type == "FARGATE" ? [] : [

--- a/variables.tf
+++ b/variables.tf
@@ -75,3 +75,8 @@ variable "opentelemetry_http_endpoint" {
 variable "enabled" {
   default = true
 }
+
+variable "docker_labels" {
+  type    = map(string)
+  default = {}
+}


### PR DESCRIPTION
https://docs.datadoghq.com/containers/docker/integrations/?tab=dockeradv2
this will allow us to configure the datadog agent to monitor postgres